### PR TITLE
Implement GCS Perf Prober

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-gcs-perf-prober

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,78 @@
+package(default_visibility = ["//visibility:private"])
+
+# Remember: all targets require the following environment variable:
+#    BAZEL_CXXOPTS="-std=c++17"
+
+cc_library(
+  name = "metrics_tracker",
+  srcs = ["metrics_tracker.cc"],
+  hdrs = ["metrics_tracker.hpp"],
+  deps = [
+    "@streaming-percentiles//cpp:cpp",
+  ]
+)
+
+cc_library(
+  name = "perftest_config",
+  srcs = ["perftest_config.cc"],
+  hdrs = ["perftest_config.hpp"],
+  deps = [
+    ":universes",
+        "@com_google_absl//absl/flags:flag",
+         "@com_google_absl//absl/strings",
+  ]
+)
+
+cc_library(
+  name = "universes",
+  hdrs = ["universes.hpp"]
+)
+
+cc_library(
+  name = "prometheus_reporter",
+  srcs = ["prometheus_reporter.cc"],
+  hdrs = ["prometheus_reporter.hpp"],
+  deps = [
+    "@com_github_jupp0r_prometheus_cpp//push",
+  ]
+)
+
+cc_library(
+  name = "test_runner",
+  srcs = ["test_runner.cc"],
+  hdrs = ["test_runner.hpp"],
+  deps = [
+    ":gcs_client",
+    ":metrics_tracker",
+    ":perftest_config",
+    ":prometheus_reporter",
+    "@com_google_absl//absl/time",
+    "@com_google_absl//absl/flags:flag",
+  ]
+)
+
+cc_library(
+  name = "gcs_client",
+  srcs = ["gcs_client.cc"],
+  hdrs = ["gcs_client.hpp"],
+  deps = [
+    ":universes",
+    "@google_cloud_cpp//:experimental-storage-grpc",
+  ]
+)
+
+cc_binary(
+  name = "gcs_perf_prober",
+  srcs = ["gcs_perf_prober.cc"],
+  deps = [
+    ":metrics_tracker",
+    "@google_cloud_cpp//:experimental-storage-grpc",
+    ":prometheus_reporter",
+    ":perftest_config",
+    ":gcs_client",
+    ":test_runner",
+    "@com_google_absl//absl/flags:flag",
+    "@com_google_absl//absl/flags:parse",
+  ]
+)
+

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package(default_visibility = ["//visibility:private"])
 
 # Remember: all targets require the following environment variable:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ubuntu:22.10
 
 # Curl necessary for ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:22.10
+
+# Curl necessary for ca-certificates
+# net-tools for online diagnostics
+RUN apt-get -qq update
+RUN apt-get install -y -q curl apt-transport-https net-tools
+
+WORKDIR /usr/perf-prober
+COPY /target/gcs_perf_prober .
+COPY run_scripts/docker_launch.sh .
+
+
+CMD "/usr/perf-prober/docker_launch.sh" 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# GCS Performance Prober
+
+This repository contains a small tool for measuring and monitoring
+the performance of Google Cloud Storage's various APIs against each
+other. It's intended to be used within Google Cloud and supports
+reporting the results to a Prometheus database.
+
+Measuring/monitoring GCS performance on an ongoing basis is potentially
+expensive and not something almost anyone would want to do. Be careful
+using a tool like this.
+
+## How to use
+
+1. Clone it from GitHub.
+2. Build it: `bazel build :gcs-perf-prober`
+3. Run some test scenario:
+
+``` shell
+    bazel run :gcs-perf-prober -- \
+        --universe=prod --api=json --scenario=small-reads \
+        --region=us-central1 --operation=ReadObject \
+        --object_name=100K --run_duration=1m
+```
+
+## Contributing
+
+You probably don't want to? But pull requests are fine.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,80 @@
+workspace(name = "cloud-cpp-mini-client")
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
+    name = "google_cloud_cpp",
+    remote = "https://github.com/googleapis/google-cloud-cpp.git",
+    branch = "main",
+)
+
+# Alternate to above, for grabbing specific client snapshots
+#load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+#http_archive(
+#    name = "google_cloud_cpp",
+#    sha256 = "ac93ef722d08bfb220343bde2f633c7c11f15e34ec3ecd0a57dbd3ff729cc3a6",
+#    strip_prefix = "google-cloud-cpp-2.5.0",
+#    url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.5.0.tar.gz",
+#)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+grpc_extra_deps()
+
+# For capturing p50, p99, etc.
+git_repository(
+    name = "streaming-percentiles",
+    remote = "https://github.com/BrandonY/streaming-percentiles.git",
+    # using a fork until pull request for supporting Bazel 6 is submitted.
+    #remote = "https://github.com/sengelha/streaming-percentiles.git",
+    branch = "main",
+)
+
+# The cloud storage C++ repo depends on a cURL target named "com_github_curl_curl".
+# The prometheus-cpp repo depends on a separate cURL target named "com_github_curl"
+# This declares "@com_github_curl" as an alias of "@com_github_curl_curl" in order
+# to trick prometheus-cpp into not importing a second verison of curl.
+new_local_repository(
+  name = "com_github_curl",
+  path = "fake_curl",
+  build_file = "fake_curl/BUILD.com_github_curl",
+)
+
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+http_archive(
+    name = "com_github_jupp0r_prometheus_cpp",
+    strip_prefix = "prometheus-cpp-master",
+    urls = ["https://github.com/jupp0r/prometheus-cpp/archive/master.zip"],
+)
+load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
+prometheus_cpp_repositories()
+
+# For flags
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+  name = "com_google_absl",
+  urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
+  strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
+)
+
+# absl dependency
+http_archive(
+  name = "bazel_skylib",
+  urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+  sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,18 @@
+#  Copyright 2023 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 workspace(name = "cloud-cpp-mini-client")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # exit when any command fails
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+bazel build -c opt :gcs_perf_prober
+
+# bazel-bin is a symlink out of the directory, so Docker doesn't like it.
+rm -rf target
+mkdir -p target
+mv bazel-bin/gcs_perf_prober target/
+
+# Login to Could container stuff
+gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+
+# Build the image locally
+docker build -t us-central1-docker.pkg.dev/gcs-grpc-team-testing/my-repository/gcs-perf-prober:latest .
+
+# Push the image to google cloud
+docker push us-central1-docker.pkg.dev/gcs-grpc-team-testing/my-repository/gcs-perf-prober:latest
+
+echo "Success. To start one of these, use kubectl apply. e.g.:  kubectl apply -f deployments/prod-us-east1-100k-object-read.yaml"
+echo "To stop it, kubectl get pods to get the ID, then kubectl kill."

--- a/deployments/prod-us-east1-100k-object-read.yaml
+++ b/deployments/prod-us-east1-100k-object-read.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "prod-us-east1-100k-object-read-config-dvfx"
+  namespace: "default"
+  labels:
+    app: "prod-us-east1-100k-object-read"
+data:
+  UNIVERSE: "prod"
+  SCENARIO: "100k-object-read"
+  REGION: "us-east1"
+  OPERATION: "ReadObject"
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "prod-us-east1-100k-object-read"
+  namespace: "default"
+  labels:
+    app: "prod-us-east1-100k-object-read"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "prod-us-east1-100k-object-read"
+  template:
+    metadata:
+      labels:
+        app: "prod-us-east1-100k-object-read"
+    spec:
+      hostNetwork: true
+      containers:
+      - name: "gcs-perf-prober"
+        image: "us-central1-docker.pkg.dev/gcs-grpc-team-testing/my-repository/gcs-perf-prober:latest"
+        #image: "us-central1-docker.pkg.dev/gcs-grpc-team-testing/my-repository/perf-gauge@sha256:811dbba5860dfe58330be0154d85a7c57a905396724c5ae537f0f224f7151858"
+        env:
+        - name: "UNIVERSE"
+          valueFrom:
+            configMapKeyRef:
+              key: "UNIVERSE"
+              name: "prod-us-east1-100k-object-read-config-dvfx"
+        - name: "SCENARIO"
+          valueFrom:
+            configMapKeyRef:
+              key: "SCENARIO"
+              name: "prod-us-east1-100k-object-read-config-dvfx"
+        - name: "REGION"
+          valueFrom:
+            configMapKeyRef:
+              key: "REGION"
+              name: "prod-us-east1-100k-object-read-config-dvfx"
+        - name: "OPERATION"
+          valueFrom:
+            configMapKeyRef:
+              key: "OPERATION"
+              name: "prod-us-east1-100k-object-read-config-dvfx"

--- a/deployments/prod-us-east1-100k-object-write.yaml
+++ b/deployments/prod-us-east1-100k-object-write.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "prod-us-east1-100k-object-write-config-dvfx"
+  namespace: "default"
+  labels:
+    app: "prod-us-east1-100k-object-write"
+data:
+  UNIVERSE: "prod"
+  SCENARIO: "100k-object-write"
+  REGION: "us-east1"
+  OPERATION: "ResumableWriteObject"
+  WRITE_LENGTH: "100000"
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "prod-us-east1-100k-object-write"
+  namespace: "default"
+  labels:
+    app: "prod-us-east1-100k-object-write"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "prod-us-east1-100k-object-write"
+  template:
+    metadata:
+      labels:
+        app: "prod-us-east1-100k-object-write"
+    spec:
+      hostNetwork: true
+      containers:
+      - name: "gcs-perf-prober"
+        image: "us-central1-docker.pkg.dev/gcs-grpc-team-testing/my-repository/gcs-perf-prober:latest"
+        #image: "us-central1-docker.pkg.dev/gcs-grpc-team-testing/my-repository/perf-gauge@sha256:811dbba5860dfe58330be0154d85a7c57a905396724c5ae537f0f224f7151858"
+        env:
+        - name: "UNIVERSE"
+          valueFrom:
+            configMapKeyRef:
+              key: "UNIVERSE"
+              name: "prod-us-east1-100k-object-write-config-dvfx"
+        - name: "SCENARIO"
+          valueFrom:
+            configMapKeyRef:
+              key: "SCENARIO"
+              name: "prod-us-east1-100k-object-write-config-dvfx"
+        - name: "REGION"
+          valueFrom:
+            configMapKeyRef:
+              key: "REGION"
+              name: "prod-us-east1-100k-object-write-config-dvfx"
+        - name: "OPERATION"
+          valueFrom:
+            configMapKeyRef:
+              key: "OPERATION"
+              name: "prod-us-east1-100k-object-write-config-dvfx"
+        - name: "WRITE_LENGTH"
+          valueFrom:
+            configMapKeyRef:
+              key: "WRITE_LENGTH"
+              name: "prod-us-east1-100k-object-write-config-dvfx"

--- a/fake_curl/BUILD.com_github_curl
+++ b/fake_curl/BUILD.com_github_curl
@@ -1,0 +1,5 @@
+alias(
+    name = "curl",
+    actual = "@com_github_curl_curl//:curl",
+    visibility = ["//visibility:public"],
+)

--- a/fake_curl/BUILD.com_github_curl
+++ b/fake_curl/BUILD.com_github_curl
@@ -1,3 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 alias(
     name = "curl",
     actual = "@com_github_curl_curl//:curl",

--- a/gcs_client.cc
+++ b/gcs_client.cc
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "gcs_client.hpp"
 
 #include "google/cloud/storage/client.h"

--- a/gcs_client.cc
+++ b/gcs_client.cc
@@ -1,0 +1,132 @@
+#include "gcs_client.hpp"
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/grpc_plugin.h"
+#include <grpc++/grpc++.h>
+
+#include <algorithm>
+
+namespace gc = ::google::cloud;
+namespace gcs = gc::storage;
+namespace gcs_experimental = gc::storage_experimental;
+
+std::map<Universe, std::string> directpath_endpoint_map = {
+    {PROD, "google-c2p:///storage.googleapis.com"},
+    {PREPROD, "google-c2p-experimental:///storage-preprod-test-grpc.googleusercontent.com"},
+    {HP_PREPROD, "google-c2p:///gcshp-central1-storage-preprod-test-grpc.googleusercontent.com"},
+};
+
+std::map<Universe, std::string> json_endpoint_map = {
+    {PROD, "https://storage.googleapis.com"},
+    {PREPROD, "https://storage-preprod-test-unified.googleusercontent.com"},
+    {HP_PREPROD, "https://gcshp-central1-storage-preprod-test-unified.googleusercontent.com"} // path: /storage/v1_preprod
+};
+
+std::map<Universe, std::string> json_version_map = {
+    {PROD, "v1"},
+    {PREPROD, "v1_preprod"},
+    {HP_PREPROD, "v1_preprod"}};
+
+GcsClient::GcsClient(google::cloud::storage::Client client, std::string bucket) : client_(client), bucket_(bucket), io_buffer_(262144)
+{
+    random_write_buffer_len_ = 2097152;
+    // Probably faster/better to read from /dev/urandom?
+    random_write_buffer_ = std::make_unique<char[]>(random_write_buffer_len_);
+    for (unsigned long i = 0; i < random_write_buffer_len_; i++)
+    {
+        random_write_buffer_[i] = (char)rand();
+    }
+};
+
+std::unique_ptr<GcsClient> GcsClient::MakeDirectpathClient(Universe universe, std::string bucket)
+{
+    gc::Options options{};
+    options.set<gcs_experimental::GrpcPluginOption>("media")
+        .set<gc::EndpointOption>(directpath_endpoint_map[universe]);
+    gcs::Client client = google::cloud::storage_experimental::DefaultGrpcClient(options);
+
+    return std::unique_ptr<GcsClient>(new GcsClient(client, bucket));
+}
+
+std::unique_ptr<GcsClient> GcsClient::MakeJSONClient(Universe universe, std::string bucket)
+{
+    gc::Options options{};
+    options.set<gcs_experimental::GrpcPluginOption>("none")
+        .set<google::cloud::storage::RestEndpointOption>(json_endpoint_map[universe])
+        .set<google::cloud::storage::internal::TargetApiVersionOption>(json_version_map[universe]);
+    gcs::Client client = google::cloud::storage_experimental::DefaultGrpcClient(options);
+
+    return std::unique_ptr<GcsClient>(new GcsClient(client, bucket));
+}
+
+bool GcsClient::ReadObject(std::string object)
+{
+    auto stream = client_.ReadObject(bucket_, object);
+    if (stream.bad())
+    {
+        std::cerr << "Error reading object: " << stream.status() << "\n";
+        return false;
+    }
+    do
+    {
+        stream.read(io_buffer_.data(), io_buffer_.size());
+        if (stream.bad())
+        {
+            std::cerr << "Error reading object: " << stream.status() << "\n";
+            return false;
+        }
+    } while (stream);
+    stream.Close();
+    if (stream.bad())
+    {
+        std::cerr << "Error closing read object: " << stream.status() << "\n";
+        return false;
+    }
+
+    return true;
+}
+
+bool GcsClient::ResumablyWriteObject(std::string object, unsigned long bytes)
+{
+    gcs::ObjectWriteStream stream = client_.WriteObject(bucket_, object, gcs::UseResumableUploadSession(gcs::NewResumableUploadSession()));
+    if (stream.bad())
+    {
+        std::cerr << "Error starting resumable uploads: " << stream.metadata().status() << "\n";
+        return false;
+    }
+    last_session_id_ = stream.resumable_session_id();
+
+    unsigned long written = 0;
+    while (written < bytes)
+    {
+        unsigned long to_write = std::min(random_write_buffer_len_, bytes - written);
+        stream.write(random_write_buffer_.get(), to_write);
+        written += to_write;
+
+        if (stream.bad())
+        {
+            std::cerr << "Error writing to the stream: " << stream.metadata().status() << "\n";
+            return false;
+        }
+    }
+    stream.Close();
+    if (stream.bad())
+    {
+        std::cerr << "Error Finishing resumable uploads: " << stream.metadata().status() << "\n";
+        return false;
+    }
+    return true;
+}
+
+bool GcsClient::OneShotWriteObject(std::string object, unsigned long bytes) { return false; }
+void GcsClient::StartResumableWrite(std::string object) {}
+
+std::string GcsClient::GRPCVersion()
+{
+    return grpc::Version();
+}
+
+std::string GcsClient::GCSClientVersion()
+{
+    return gc::version_string();
+}

--- a/gcs_client.hpp
+++ b/gcs_client.hpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef __GCS_CLIENT_HPP_
 #define __GCS_CLIENT_HPP_
 

--- a/gcs_client.hpp
+++ b/gcs_client.hpp
@@ -1,0 +1,44 @@
+#ifndef __GCS_CLIENT_HPP_
+#define __GCS_CLIENT_HPP_
+
+#include <string>
+#include <memory>
+
+#include "google/cloud/storage/client.h"
+
+#include "universes.hpp"
+
+class GcsClient
+{
+public:
+    static std::unique_ptr<GcsClient> MakeDirectpathClient(Universe universe, std::string bucket);
+    static std::unique_ptr<GcsClient> MakeJSONClient(Universe universe, std::string bucket);
+
+    // GcsClient(const GcsClient &) = delete;
+    // GcsClient &operator=(const GcsClient &) = delete;
+
+    bool ReadObject(std::string object);
+    bool ResumablyWriteObject(std::string object, unsigned long bytes);
+    bool OneShotWriteObject(std::string object, unsigned long bytes);
+    void StartResumableWrite(std::string object);
+
+    static std::string GRPCVersion();
+    static std::string GCSClientVersion();
+
+    // For logging/diagnostics
+    std::string LastSessionId() { return last_session_id_; }
+
+private:
+    GcsClient(google::cloud::storage::Client client, std::string bucket);
+
+    google::cloud::storage::Client client_;
+    const std::string bucket_;
+    unsigned long random_write_buffer_len_;
+    std::unique_ptr<char[]> random_write_buffer_;
+
+    std::vector<char> io_buffer_;
+
+    std::string last_session_id_;
+};
+
+#endif // __GCS_CLIENT_HPP_

--- a/gcs_perf_prober.cc
+++ b/gcs_perf_prober.cc
@@ -1,3 +1,17 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/grpc_plugin.h"

--- a/gcs_perf_prober.cc
+++ b/gcs_perf_prober.cc
@@ -1,0 +1,74 @@
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/grpc_plugin.h"
+
+#include <iostream>
+#include <vector>
+
+#include <prometheus/gauge.h>
+#include <prometheus/registry.h>
+#include <prometheus/gateway.h>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+
+#include "prometheus_reporter.hpp"
+#include "perftest_config.hpp"
+#include "gcs_client.hpp"
+#include "test_runner.hpp"
+
+ABSL_FLAG(bool, push_to_prometheus, false, "Whether to push results");
+ABSL_FLAG(std::string, prometheus_host, "34.173.12.152", "Prometheus Push Host");
+ABSL_FLAG(std::string, prometheus_port, "9091", "Prometheus Push Port");
+ABSL_FLAG(bool, run_once, false, "Whether to exit after first successful run, for testing, etc");
+
+namespace gc = ::google::cloud;
+namespace gcs = gc::storage;
+namespace gcs_experimental = gc::storage_experimental;
+
+#include <stdio.h>
+#include <execinfo.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+
+void handler(int sig) {
+  void *array[10];
+  size_t size;
+
+  // get void*'s for all entries on the stack
+  size = backtrace(array, 10);
+
+  // print out all the frames to stderr
+  fprintf(stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
+}
+
+
+int main(int argc, char **argv)
+{
+    absl::ParseCommandLine(argc, argv);
+    std::optional<PerftestConfig> config = PerftestConfig::LoadConfig();
+    if (!config)
+    {
+        return 1;
+    }
+
+    PrometheusReporter prometheus_reporter(absl::GetFlag(FLAGS_prometheus_host), absl::GetFlag(FLAGS_prometheus_port), config->scenario(), config->clientAPI_str(), config->region(), config->universe_str(), GcsClient::GRPCVersion(), GcsClient::GCSClientVersion());
+
+    do
+    {
+        TestRunner testRunner(*config);
+        testRunner.Run(&prometheus_reporter);
+
+        prometheus_reporter.Summarize();
+        if (absl::GetFlag(FLAGS_push_to_prometheus))
+        {
+            prometheus_reporter.Push();
+        }
+    } while (!absl::GetFlag(FLAGS_run_once));
+
+    return 0;
+}

--- a/metrics_tracker.cc
+++ b/metrics_tracker.cc
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "metrics_tracker.hpp"
 
 #include <stmpct/ckms_tq.hpp>

--- a/metrics_tracker.cc
+++ b/metrics_tracker.cc
@@ -1,0 +1,38 @@
+#include "metrics_tracker.hpp"
+
+#include <stmpct/ckms_tq.hpp>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+
+MetricsTracker::MetricsTracker() : success_latency_tracker_(quantiles_.begin(), quantiles_.end())
+{
+}
+
+void MetricsTracker::ReportSuccess(double latency)
+{
+    success_latency_tracker_.insert(latency);
+    success_count_ += 1;
+    request_count_ += 1;
+}
+
+void MetricsTracker::ReportError(double latency)
+{
+    request_count_ += 1;
+}
+
+double MetricsTracker::Quantile(double p)
+{
+    for (stmpct::targeted_quantile q : quantiles_)
+    {
+        if (q.phi == p)
+        {
+            return success_latency_tracker_.quantile(p);
+            ;
+        }
+    }
+
+    std::cerr << "Request for quantile " << p << ", which is not tracked.";
+    exit(1);
+    return 0;
+}

--- a/metrics_tracker.hpp
+++ b/metrics_tracker.hpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef metrics_tracker_hpp__
 #define metrics_tracker_hpp__
 

--- a/metrics_tracker.hpp
+++ b/metrics_tracker.hpp
@@ -1,0 +1,29 @@
+#ifndef metrics_tracker_hpp__
+#define metrics_tracker_hpp__
+
+#include <stmpct/ckms_tq.hpp>
+
+class MetricsTracker
+{
+public:
+  MetricsTracker();
+
+  MetricsTracker(const MetricsTracker &) = delete;
+  MetricsTracker &operator=(const MetricsTracker &) = delete;
+
+  void ReportSuccess(double latency);
+  void ReportError(double latency);
+
+  double Quantile(double p);
+  
+  unsigned long successes() { return success_count_; }
+  unsigned long requests() { return request_count_; }
+
+private:
+  unsigned long request_count_ = 0;
+  unsigned long success_count_ = 0;
+  std::vector<stmpct::targeted_quantile> quantiles_ = {{0.5, 0.0001}, {.9, .0001}, {.99, .0001}};
+  stmpct::ckms_tq<double> success_latency_tracker_;
+};
+
+#endif // metrics_tracker_hpp__

--- a/perftest_config.cc
+++ b/perftest_config.cc
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "perftest_config.hpp"
 
 #include "absl/flags/flag.h"

--- a/perftest_config.cc
+++ b/perftest_config.cc
@@ -1,0 +1,140 @@
+#include "perftest_config.hpp"
+
+#include "absl/flags/flag.h"
+#include "absl/strings/str_cat.h"
+
+#include <iostream>
+#include <optional>
+
+ABSL_FLAG(std::optional<std::string>, universe, std::nullopt, "prod or preprod");
+ABSL_FLAG(std::optional<std::string>, scenario, std::nullopt, "Name of the scenario, for example 100k-object-read");
+ABSL_FLAG(std::optional<std::string>, region, std::nullopt, "Name of the scenario, for example 100k-object-read");
+ABSL_FLAG(std::optional<std::string>, api, std::nullopt, "grpc, grpc-no-directparth, json");
+
+ABSL_FLAG(std::optional<std::string>, operation, std::nullopt, "ReadObject, WriteObject, etc");
+ABSL_FLAG(std::optional<std::string>, object_name, std::nullopt, "Name of object to read/write");
+
+ABSL_FLAG(std::optional<long>, write_length, std::nullopt, "For write operations, object size");
+
+std::optional<PerftestConfig> PerftestConfig::LoadConfig()
+{
+    if (!absl::GetFlag(FLAGS_universe).has_value())
+    {
+        std::cerr << "You must set the 'universe' flag to 'prod' or 'preprod'" << std::endl;
+        return std::nullopt;
+    }
+    if (!absl::GetFlag(FLAGS_api).has_value())
+    {
+        std::cerr << "You must set the 'api' flag to 'grpc', 'grpc-no-directpath', or 'json'" << std::endl;
+        return std::nullopt;
+    }
+    if (!absl::GetFlag(FLAGS_scenario).has_value())
+    {
+        std::cerr << "Must specify 'scenario'" << std::endl;
+        return std::nullopt;
+    }
+    if (!absl::GetFlag(FLAGS_region).has_value())
+    {
+        std::cerr << "Must specify 'region'" << std::endl;
+        return std::nullopt;
+    }
+    if (!absl::GetFlag(FLAGS_operation).has_value())
+    {
+        std::cerr << "Must specify 'operation'" << std::endl;
+        return std::nullopt;
+    }
+    if (!absl::GetFlag(FLAGS_object_name).has_value())
+    {
+        std::cerr << "Must specify 'object_name'" << std::endl;
+        return std::nullopt;
+    }
+
+    ClientAPI api;
+    if (absl::GetFlag(FLAGS_api) == "grpc")
+    {
+        api = GRPC_DIRECTPATH;
+    }
+    else if (absl::GetFlag(FLAGS_api) == "json")
+    {
+        api = JSON;
+    }
+    else
+    {
+        std::cerr << "You must set the 'api' flag to 'grpc', 'grpc-no-directpath', or 'json'" << std::endl;
+        return std::nullopt;
+    }
+
+    std::string bucket_prefix;
+
+    Universe universe;
+    if (absl::GetFlag(FLAGS_universe) == "prod")
+    {
+        universe = PROD;
+        bucket_prefix = "gcs-grpc-team-perf-testing";
+    }
+    else if (absl::GetFlag(FLAGS_universe) == "preprod")
+    {
+        universe = PREPROD;
+        bucket_prefix = "gcs-grpc-team-preprod-perf";
+    }
+    else
+    {
+        std::cerr << "You must set the 'universe' flag to 'prod' or 'preprod'" << std::endl;
+        return std::nullopt;
+    }
+
+    Operation operation;
+    if (absl::GetFlag(FLAGS_operation) == "ReadObject")
+    {
+        operation = READ;
+    }
+    else if (absl::GetFlag(FLAGS_operation) == "OneShotWriteObject")
+    {
+        operation = ONESHOT_WRITE;
+    }
+    else if (absl::GetFlag(FLAGS_operation) == "ResumableWriteObject")
+    {
+        operation = RESUMABLE_WRITE;
+    }
+    else
+    {
+        std::cerr << "You must set the 'operation' flag to a known operation" << std::endl;
+        return std::nullopt;
+    }
+
+    long write_length = 0;
+    if (operation == ONESHOT_WRITE || operation == RESUMABLE_WRITE)
+    {
+        if (!absl::GetFlag(FLAGS_write_length).has_value())
+        {
+            std::cerr << "You must set the a 'write_length' in bytes for write calls" << std::endl;
+            return std::nullopt;
+        }
+        write_length = absl::GetFlag(FLAGS_write_length).value();
+    }
+
+    std::string scenario = *absl::GetFlag(FLAGS_scenario);
+    std::string region = *absl::GetFlag(FLAGS_region);
+    std::string bucket = absl::StrCat(bucket_prefix, "-", region, "-", scenario);
+    std::string object = *absl::GetFlag(FLAGS_object_name);
+
+    return std::make_optional<PerftestConfig>({scenario, region,
+                                               universe, api, operation, bucket, object, write_length});
+}
+
+std::string PerftestConfig::universe_str() {
+    switch(universe_) {
+        case PROD: return "prod";
+        case PREPROD: return "preprod";
+        case HP_PREPROD: return "hp-preprod";
+    }
+    return nullptr;
+}
+
+std::string PerftestConfig::clientAPI_str() {
+    switch(clientAPI_) {
+        case GRPC_DIRECTPATH: return "gRPC";
+        case JSON: return "JSON";
+    }
+    return nullptr;
+}

--- a/perftest_config.hpp
+++ b/perftest_config.hpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef __PERF_SCENARIO_HPP_
 #define __PERF_SCENARIO_HPP_
 

--- a/perftest_config.hpp
+++ b/perftest_config.hpp
@@ -1,0 +1,63 @@
+#ifndef __PERF_SCENARIO_HPP_
+#define __PERF_SCENARIO_HPP_
+
+#include <string>
+#include <optional>
+
+#include "universes.hpp"
+
+enum Operation
+{
+    READ,
+    RESUMABLE_WRITE,
+    ONESHOT_WRITE,
+    QUERY_WRITE_STATUS,
+};
+
+enum ClientAPI
+{
+    GRPC_DIRECTPATH,
+    JSON
+};
+
+class PerftestConfig
+{
+public:
+    static std::optional<PerftestConfig> LoadConfig();
+
+    PerftestConfig &operator=(const PerftestConfig &) = delete;
+
+    std::string scenario() { return scenario_; }
+    std::string region() { return region_; }
+    Universe universe() { return universe_; }
+    std::string universe_str();
+    ClientAPI clientAPI() { return clientAPI_; }
+    std::string clientAPI_str();
+    Operation operation() { return operation_; }
+    std::string bucket() { return bucket_; }
+    std::string object() { return object_; }
+
+    long write_length() { return write_length_; }
+
+private:
+    PerftestConfig(std::string scenario, std::string region,
+                   Universe universe, ClientAPI clientAPI, Operation operation, std::string bucket, std::string object, long write_length) : scenario_(scenario),
+                                                                                                                                             region_(region),
+                                                                                                                                             universe_(universe),
+                                                                                                                                             clientAPI_(clientAPI),
+                                                                                                                                             operation_(operation),
+                                                                                                                                             bucket_(bucket),
+                                                                                                                                             object_(object),
+                                                                                                                                             write_length_(write_length){};
+
+    const std::string scenario_;
+    const std::string region_;
+    const Universe universe_;
+    const ClientAPI clientAPI_;
+    const Operation operation_;
+    const std::string bucket_;
+    const std::string object_;
+    const double write_length_;
+};
+
+#endif

--- a/prometheus_reporter.cc
+++ b/prometheus_reporter.cc
@@ -1,0 +1,84 @@
+#include "prometheus_reporter.hpp"
+
+#include <string>
+#include <iostream>
+
+#include <prometheus/gauge.h>
+#include <prometheus/registry.h>
+#include <prometheus/gateway.h>
+#include <prometheus/counter.h>
+
+PrometheusReporter::PrometheusReporter(std::string host, std::string port,
+                                       std::string scenario, std::string api, std::string location, std::string universe, std::string grpc_version, std::string gcs_client_version) : registry_(std::make_shared<prometheus::Registry>()),
+                                                                                                                         gateway_(host, port, "gcs-perf-prober", 
+                                                                                                                         // Gateway labels map to what each call to push gateway overwrites.
+                                                                                                                         // They must be unique to each separate running prober job.
+                                                                                                                         {
+                                                                                                                            {"testname", scenario},
+                                                                                                                            {"universe", universe},
+                                                                                                                            {"api", api},
+                                                                                                                            {"location", location},
+                                                                                                                         }),
+                                                                                                                         labels_({{"testname", scenario},
+                                                                                                                            {"grpc_client_version", grpc_version},
+                                                                                                                            {"universe", universe},
+                                                                                                                            {"api", api},
+                                                                                                                            {"location", location},
+                                                                                                                            {"gcs_client_version", gcs_client_version}}),
+                                                                                                                         success_p50_gauge_family_(prometheus::BuildGauge().Name("success_latency_p50").Register(*registry_)),
+                                                                                                                         success_p50_gauge_(success_p50_gauge_family_.Add(labels_)),
+                                                                                                                         success_p90_gauge_family_(prometheus::BuildGauge().Name("success_latency_p90").Register(*registry_)),
+                                                                                                                         success_p90_gauge_(success_p90_gauge_family_.Add(labels_)),
+                                                                                                                         success_count_family_(prometheus::BuildGauge().Name("success_count").Register(*registry_)),
+                                                                                                                         success_count_(success_count_family_.Add(labels_)),
+                                                                                                                         request_count_family_(prometheus::BuildGauge().Name("request_count").Register(*registry_)),
+                                                                                                                         request_count_(request_count_family_.Add(labels_))
+{
+    gateway_.RegisterCollectable(registry_);
+}
+
+void PrometheusReporter::RecordSuccessP50(double latency)
+{
+    success_p50_gauge_.Set(latency);
+}
+
+void PrometheusReporter::RecordSuccessP90(double latency)
+{
+    success_p90_gauge_.Set(latency);
+}
+
+void PrometheusReporter::ReportSuccesses(long count)
+{
+    success_count_.Set(count);
+}
+
+void PrometheusReporter::ReportCalls(long count)
+{
+    request_count_.Set(count);
+}
+
+void PrometheusReporter::Summarize()
+{
+    std::cout << "------------" << std::endl
+              << "Summary:" << std::endl
+              << "  p50: " << (success_p50_gauge_.Value() / 1000.0) << std::endl
+              << "  p90: " << (success_p90_gauge_.Value() / 1000.0) << std::endl
+              << "  Successful requests: " << success_count_.Value() << std::endl
+              << "  Errors: " << (request_count_.Value() - success_count_.Value()) << std::endl;
+}
+
+bool PrometheusReporter::Push()
+{
+    int code = gateway_.Push();
+    if (code != 200)
+    {
+        std::cerr << "Prometheus push failed with status " << code << std::endl;
+        return false;
+    }
+    else
+    {
+        std::cout << "Metrics pushed." << std::endl;
+        return true;
+    }
+    
+}

--- a/prometheus_reporter.cc
+++ b/prometheus_reporter.cc
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "prometheus_reporter.hpp"
 
 #include <string>

--- a/prometheus_reporter.hpp
+++ b/prometheus_reporter.hpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef __PROMETHEUS_REPORTER_HPP_
 #define __PROMETHEUS_REPORTER_HPP_
 

--- a/prometheus_reporter.hpp
+++ b/prometheus_reporter.hpp
@@ -1,0 +1,49 @@
+#ifndef __PROMETHEUS_REPORTER_HPP_
+#define __PROMETHEUS_REPORTER_HPP_
+
+#include <string>
+#include <memory>
+
+#include <prometheus/gauge.h>
+#include <prometheus/registry.h>
+#include <prometheus/gateway.h>
+#include <prometheus/counter.h>
+
+class PrometheusReporter
+{
+public:
+    PrometheusReporter(std::string host, std::string port,
+                       std::string scenario, std::string api, std::string location, std::string universe, std::string grpc_version, std::string gcs_client_version);
+
+    PrometheusReporter(const PrometheusReporter &) = delete;
+    PrometheusReporter &operator=(const PrometheusReporter &) = delete;
+
+    void RecordSuccessP50(double latency);
+    void RecordSuccessP90(double latency);
+
+    void ReportSuccesses(long count);
+    void ReportCalls(long count);
+
+    bool Push();
+    void Summarize();
+
+private:
+    std::shared_ptr<prometheus::Registry> registry_;
+    prometheus::Gateway gateway_;
+    prometheus::Labels labels_;
+
+    prometheus::Family<prometheus::Gauge> &success_p50_gauge_family_;
+    prometheus::Gauge &success_p50_gauge_;
+
+    prometheus::Family<prometheus::Gauge> &success_p90_gauge_family_;
+    prometheus::Gauge &success_p90_gauge_;
+
+    // These sure LOOK like counters, but perf-gauge treated them as gauges, so sure, let's do that.
+    prometheus::Family<prometheus::Gauge> &success_count_family_;
+    prometheus::Gauge &success_count_;
+
+    prometheus::Family<prometheus::Gauge> &request_count_family_;
+    prometheus::Gauge &request_count_;
+};
+
+#endif // __PROMETHEUS_REPORTER_HPP_

--- a/run_scripts/docker_launch.sh
+++ b/run_scripts/docker_launch.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+echo "Hi, I'm Brandon's docker startup script"
+
+echo "You want me to run $SCENARIO in region $REGION in universe $UNIVERSE, for $OPERATION operation"
+
+if [[ -z "${SCENARIO}" ]]; then
+  echo "You must set SCENARIO variable"
+  exit
+fi
+
+if [[ -z "${REGION}" ]]; then
+  echo "You must set REGION variable"
+  exit
+fi
+
+if [[ -z "${UNIVERSE}" ]]; then
+  echo "You must set UNIVERSE variable"
+  exit
+fi
+
+if [[ -z "${OPERATION}" ]]; then
+  echo "You must set OPERATION variable"
+  exit
+fi
+
+if [[ "${OPERATION}" == *"Write"* ]] && [[ -z "${WRITE_LENGTH}" ]]; then
+    echo "You must set WRITE_LENGTH for WriteObject operations."
+    exit
+fi
+
+if [[ "preprod" == "$UNIVERSE" ]]; then
+	BUCKET_PREFIX="gcs-grpc-team-preprod-perf"
+else
+	BUCKET_PREFIX="gcs-grpc-team-perf-testing"
+fi
+
+export BUCKET="${BUCKET_PREFIX}-${REGION}-${SCENARIO}"
+echo "Running on bucket '$BUCKET'"
+
+./gcs_perf_prober --universe=$UNIVERSE --api=json --scenario=$SCENARIO --region=$REGION --operation=$OPERATION --object_name=100K --push_to_prometheus --run_duration=1m --write_length=$WRITE_LENGTH &
+./gcs_perf_prober --universe=$UNIVERSE --api=grpc --scenario=$SCENARIO --region=$REGION --operation=$OPERATION --object_name=100K --push_to_prometheus --run_duration=1m --write_length=$WRITE_LENGTH
+
+# And start JSON as well.

--- a/run_scripts/docker_launch.sh
+++ b/run_scripts/docker_launch.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 echo "Hi, I'm Brandon's docker startup script"
 
 echo "You want me to run $SCENARIO in region $REGION in universe $UNIVERSE, for $OPERATION operation"

--- a/test_runner.cc
+++ b/test_runner.cc
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "test_runner.hpp"
 
 #include <chrono>

--- a/test_runner.cc
+++ b/test_runner.cc
@@ -1,0 +1,85 @@
+#include "test_runner.hpp"
+
+#include <chrono>
+#include <cstdlib>
+
+#include "absl/strings/str_cat.h"
+#include "absl/time/time.h"
+#include "absl/time/clock.h"
+#include "absl/flags/flag.h"
+
+#include "perftest_config.hpp"
+#include "metrics_tracker.hpp"
+
+using namespace std::chrono;
+
+ABSL_FLAG(absl::Duration, run_duration, absl::Minutes(1), "Length of interval used to calculate p50, etc");
+
+TestRunner::TestRunner(PerftestConfig config) : config_(config)
+{
+}
+
+std::unique_ptr<GcsClient> TestRunner::CreateClient()
+{
+    std::unique_ptr<GcsClient> client;
+    switch (config_.clientAPI())
+    {
+    case GRPC_DIRECTPATH:
+        client = GcsClient::MakeDirectpathClient(config_.universe(), config_.bucket());
+        break;
+    case JSON:
+        client = GcsClient::MakeJSONClient(config_.universe(), config_.bucket());
+    }
+    return client;
+}
+
+void TestRunner::Run(PrometheusReporter *reporter)
+{
+    MetricsTracker metrics_tracker;
+    std::unique_ptr<GcsClient> client = CreateClient();
+
+    auto run_end_time = absl::Now() + absl::GetFlag(FLAGS_run_duration);
+
+    std::string object_name;
+    while (absl::Now() < run_end_time)
+    {
+        auto start = high_resolution_clock::now();
+        bool success = false;
+        switch (config_.operation())
+        {
+        case READ:
+            success = client->ReadObject(config_.object());
+            break;
+        case ONESHOT_WRITE:
+            success = client->OneShotWriteObject(absl::StrCat(config_.object(), "_", rand()), config_.write_length());
+            break;
+        case RESUMABLE_WRITE:
+            object_name = absl::StrCat(config_.object(), "_", rand());
+            success = client->ResumablyWriteObject(object_name, config_.write_length());
+            break;
+        case QUERY_WRITE_STATUS:
+            // TODO
+            break;
+        }
+
+        auto stop = high_resolution_clock::now();
+        std::chrono::duration<double, std::micro> duration = stop - start;
+
+        if ( duration > std::chrono::seconds(30)) {
+            auto d_seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+            std::cerr << "Write of object " << object_name << " needed " << d_seconds.count() << " seconds. Session ID: " << client->LastSessionId() << std::endl;
+        }
+
+        if (success)
+        {
+            metrics_tracker.ReportSuccess(duration.count());
+        } else {
+            metrics_tracker.ReportError(duration.count());
+        }
+    }
+    reporter->ReportSuccesses(metrics_tracker.successes());
+    reporter->ReportCalls(metrics_tracker.requests());
+    reporter->RecordSuccessP50(metrics_tracker.Quantile(.5));
+    reporter->RecordSuccessP90(metrics_tracker.Quantile(.9));
+    return;
+}

--- a/test_runner.hpp
+++ b/test_runner.hpp
@@ -1,0 +1,22 @@
+#ifndef __TEST_RUNNER_HPP__
+#define __TEST_RUNNER_HPP__
+
+#include "perftest_config.hpp"
+#include "gcs_client.hpp"
+#include "prometheus_reporter.hpp"
+
+#include <memory>
+
+class TestRunner
+{
+public:
+    TestRunner(PerftestConfig config);
+
+    void Run(PrometheusReporter *reporter);
+
+private:
+    PerftestConfig config_;
+    std::unique_ptr<GcsClient> CreateClient();
+};
+
+#endif // __TEST_RUNNER_HPP__

--- a/test_runner.hpp
+++ b/test_runner.hpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef __TEST_RUNNER_HPP__
 #define __TEST_RUNNER_HPP__
 

--- a/universes.hpp
+++ b/universes.hpp
@@ -1,3 +1,18 @@
+/* Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef __UNIVERSE_HPP__
 #define __UNIVERSE_HPP__
 

--- a/universes.hpp
+++ b/universes.hpp
@@ -1,0 +1,11 @@
+#ifndef __UNIVERSE_HPP__
+#define __UNIVERSE_HPP__
+
+enum Universe
+{
+    PROD,
+    PREPROD,
+    HP_PREPROD
+};
+
+#endif // __UNIVERSE_HPP__


### PR DESCRIPTION
This is a code review for the C++ version of the GCS perf prober.

A few people have started relying on this code and using it as a reference, so it's become important to start doing proper code reviews.

This is a reimplementation of the previous prober system, which was based off the Rust "perf-gauge" tool, a FFI interface to a C library that invoked the C++ GCS client library, which was a bit of a nightmare. Instead, this is a small, pure C++ program that invokes the client library, does the timing, calculates the P50s and such, and then pushes the results to Prometheus, removing the need for the perf-gauge library.

Also included is configuration for Docker/Kubernetes/GKE, which allows for many instances to be deployed and managed automatically instead of manually maintaining a fleet of VMs.

Of particular interest in this review is whether I'm invoking the client library in a correct and optimal manner.